### PR TITLE
i1205 - build jekyll pages without using github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 static
+_bundle

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-_site/
+static

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.1)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)
     ffi (1.9.18)
     forwardable-extended (2.6.0)
@@ -24,7 +24,7 @@ GEM
       sass (~> 3.4)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
-    kramdown (1.13.2)
+    kramdown (1.15.0)
     liquid (3.0.6)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -32,13 +32,17 @@ GEM
     mercenary (0.3.6)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
-    public_suffix (2.0.5)
-    rb-fsevent (0.9.8)
-    rb-inotify (0.9.8)
-      ffi (>= 0.5.0)
+    public_suffix (3.0.0)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     rouge (1.11.1)
     safe_yaml (1.0.4)
-    sass (3.4.24)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
 
 PLATFORMS
   ruby
@@ -49,7 +53,7 @@ DEPENDENCIES
   jekyll-paginate
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.4.2p198
 
 BUNDLED WITH
-   1.13.6
+   1.15.4

--- a/README.md
+++ b/README.md
@@ -56,3 +56,36 @@ Posts are created in exactly the same way as regular pages: you still need to ma
 The general layout of the pages can't be changed easily.  But things like colour, spacing, fonts, and any other CSS style can easily be changed by adding CSS rules to the [`vimc.css`](./css/vimc.css) file. For example, you can change the size of the text, or the background colour of the navigation bar, or the colour of the text in the footer.
 
 Note that the template was designed in a way such that it changes drastically when you view it on a big screen (laptop) vs a small screen (phone)
+
+## Building the site
+
+### Locally
+
+Run
+
+```
+./build.sh .
+```
+
+which will update the contents of the `static` directory with the new website.  This is what happens on teamcity.
+
+### Transient test
+
+Running
+
+```
+./build.sh
+```
+
+Which will clone the website (the master branch), set up jekyll and build the website, then disappear
+
+### Into volume
+
+Run
+
+```
+docker volume create vimc-website-volume
+./build.sh vimc-website-volume origin/master
+```
+
+The last argument is the reference (hash, branch, tag, etc) to build.  The default is `origin/master`.  This will clone or update the sources within the volume, then set the sources to the required reference (use `HEAD` to prevent this), then build the site.  Gems are cached into the volume and the built website appears at `static`.

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,8 @@
 url: "http://vimchub.github.io"
 baseurl: ""
 
+destination: static
+
 title: Vaccine Impact Modelling Consortium
 description: The Vaccine Impact Modelling Consortium (VIMC) was established in 2016 for a period of five years to coordinate the ongoing work of several groups focusing on vaccine impact modelling.
 

--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,5 @@ fi
 
 docker run -t --rm \
        $VOLUME_MAP \
-       -u ${UID} \
        $IMAGE \
        build-site.sh $BRANCH

--- a/build.sh
+++ b/build.sh
@@ -20,4 +20,5 @@ fi
 docker run -t --rm \
        $VOLUME_MAP \
        $IMAGE \
+       -u ${UID} \
        build-site.sh $BRANCH

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+JEKYLL_VERSION=3.3.1
+
+JEKYLL_IMAGE=jekyll/builder:$JEKYLL_VERSION
+BUNDLE_CACHE=vimc-website-bundle-cache
+
+docker pull $JEKYLL_IMAGE
+
+docker volume create $BUNDLE_CACHE
+
+docker run --rm \
+       -v $BUNDLE_CACHE:/usr/local/bundle \
+       -v ${PWD}:/srv/jekyll \
+       $JEKYLL_IMAGE \
+       jekyll build

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ else
     VOLUME_MAP="-v $VOLUME:/srv/jekyll"
 fi
 
-docker run -it --rm \
+docker run -t --rm \
        $VOLUME_MAP \
        $IMAGE \
        build-site.sh $BRANCH

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 IMAGE=docker.montagu.dide.ic.ac.uk:5000/vimc-website-builder:i1205
-#docker pull $IMAGE
+docker pull $IMAGE
 VOLUME=$1
 BRANCH=$2
 if [ -z $VOLUME ]; then

--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,6 @@ fi
 
 docker run -t --rm \
        $VOLUME_MAP \
-       $IMAGE \
        -u ${UID} \
+       $IMAGE \
        build-site.sh $BRANCH

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
-JEKYLL_VERSION=3.3.1
+set -ex
+IMAGE=docker.montagu.dide.ic.ac.uk:5000/vimc-website-builder:i1205
+#docker pull $IMAGE
+VOLUME=$1
+BRANCH=$2
+if [ -z $VOLUME ]; then
+    VOLUME_MAP=""
+else
+    if [ "$VOLUME" == . ]; then
+        VOLUME=$PWD
+    fi
+    if [ "$VOLUME" == "$PWD" ]; then
+        BRANCH=HEAD
+        shift
+    fi
+    VOLUME_MAP="-v $VOLUME:/srv/jekyll"
+fi
 
-JEKYLL_IMAGE=jekyll/builder:$JEKYLL_VERSION
-BUNDLE_CACHE=vimc-website-bundle-cache
-
-docker pull $JEKYLL_IMAGE
-
-docker volume create $BUNDLE_CACHE
-
-docker run --rm \
-       -v $BUNDLE_CACHE:/usr/local/bundle \
-       -v ${PWD}:/srv/jekyll \
-       $JEKYLL_IMAGE \
-       jekyll build
+docker run -it --rm \
+       $VOLUME_MAP \
+       $IMAGE \
+       build-site.sh $BRANCH

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,2 @@
+FROM jekyll/builder:3.3.1
+COPY build-site.sh /usr/local/bin/build-site.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,2 +1,5 @@
 FROM jekyll/builder:3.3.1
+ENV USER_BUNDLE_CACHE=$JEKYLL_DATA_DIR/_bundle
+RUN mv /usr/local/bundle /usr/local/bundle_src && \
+        ln -s $USER_BUNDLE_CACHE /usr/local/bundle
 COPY build-site.sh /usr/local/bin/build-site.sh

--- a/docker/build-site.sh
+++ b/docker/build-site.sh
@@ -8,7 +8,7 @@ SRC=/srv/jekyll
 BRANCH=$1
 BUNDLE_CACHE=$SRC/_bundle
 if [ -z "$BRANCH" ]; then
-ls    BRANCH=origin/master
+    BRANCH=origin/master
 fi
 
 if [ $BRANCH == "HEAD" ]; then

--- a/docker/build-site.sh
+++ b/docker/build-site.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+
+# NOTE: this runs in the jekyll containers plain bourne shell so bash
+# extensions are unlikely to work
+
+set -ex
+SRC=/srv/jekyll
+BRANCH=$1
+BUNDLE_CACHE=$SRC/_bundle
+if [ -z "$BRANCH" ]; then
+ls    BRANCH=origin/master
+fi
+
+if [ $BRANCH == "HEAD" ]; then
+    echo "Not updating git HEAD"
+    if [ ! -d $SRC/.git ]; then
+        echo "Can't use branch 'HEAD' if sources are not already checked out"
+        exit 1
+    fi
+else
+    if [ -d $SRC/.git ]; then
+        echo "Updating existing website sources"
+        git -C $SRC fetch
+    else
+        echo "Fetching website sources"
+        git clone https://github.com/vimc/vimc-website $SRC
+    fi
+    echo "Setting git to $BRANCH"
+    git -C $SRC reset --hard $BRANCH
+fi
+
+if [ -d $BUNDLE_CACHE ]; then
+    echo "Bundle cache already set up"
+else
+    echo "Setting up bundle cache"
+    mv /usr/local/bundle/ $BUNDLE_CACHE
+fi
+rm -rf /usr/local/bundle
+ln -s $BUNDLE_CACHE /usr/local/bundle
+
+echo "Building website"
+jekyll build

--- a/docker/build-site.sh
+++ b/docker/build-site.sh
@@ -6,7 +6,6 @@
 set -ex
 SRC=/srv/jekyll
 BRANCH=$1
-BUNDLE_CACHE=$SRC/_bundle
 if [ -z "$BRANCH" ]; then
     BRANCH=origin/master
 fi
@@ -29,14 +28,12 @@ else
     git -C $SRC reset --hard $BRANCH
 fi
 
-if [ -d $BUNDLE_CACHE ]; then
+if [ -d $USER_BUNDLE_CACHE ]; then
     echo "Bundle cache already set up"
 else
     echo "Setting up bundle cache"
-    mv /usr/local/bundle/ $BUNDLE_CACHE
+    cp -r /usr/local/bundle_src $USER_BUNDLE_CACHE
 fi
-rm -rf /usr/local/bundle
-ln -s $BUNDLE_CACHE /usr/local/bundle
 
 echo "Building website"
 jekyll build

--- a/docker/teamcity-build-image.sh
+++ b/docker/teamcity-build-image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+GIT_ID=$(git rev-parse --short=7 HEAD)
+GIT_BRANCH=$(git symbolic-ref --short HEAD)
+
+REGISTRY=docker.montagu.dide.ic.ac.uk:5000
+NAME=vimc-website-builder
+
+COMMIT_TAG=$REGISTRY/$NAME:$GIT_ID
+BRANCH_TAG=$REGISTRY/$NAME:$GIT_BRANCH
+
+docker build -t $COMMIT_TAG -t $BRANCH_TAG .
+docker push $COMMIT_TAG
+docker push $BRANCH_TAG

--- a/docker/teamcity-build-site.sh
+++ b/docker/teamcity-build-site.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-set -e
-./build.sh ${PWD}

--- a/docker/teamcity-build-site.sh
+++ b/docker/teamcity-build-site.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+./build.sh ${PWD}


### PR DESCRIPTION
This builds the pages on teamcity.  We'll still need to inject the results of successful builds into the running montagu instance but that will be a separate PR